### PR TITLE
Update URL for embedded rendered templates. This fixes #56 and fixes #58

### DIFF
--- a/electron/constants/index.ts
+++ b/electron/constants/index.ts
@@ -1,5 +1,5 @@
-export const STUDIO_ENDPOINT = "https://studio.outerbase.com/embed";
+export const STUDIO_ENDPOINT = "https://libsqlstudio.com/embed";
 
-export const OUTERBASE_WEBSITE = "https://outerbase.com";
+export const OUTERBASE_WEBSITE = "https://libsqlstudio.com";
 export const OUTERBASE_GITHUB =
   "https://github.com/outerbase/studio-desktop/issues";


### PR DESCRIPTION
I was able to use the studio-desktop a few weeks ago, but it suddenly stopped working. It seems the DNS was updated recently, which might be the reason it’s not working now. If I understand correctly, it requires a server with the templates already rendered in order to work. To use it offline or if you can’t wait, you need to clone both projects [studio-desktop](https://github.com/outerbase/studio-desktop) and [studio](https://github.com/outerbase/studio), and execute the studio-desktop with: 
`npm run dev:local-embed`
 and the studio with: 
`npm run dev`
